### PR TITLE
fix: expose namespaced bin and update usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,13 @@ npx @cotype/build-client <spec> <dest>
 Where `<spec>` is the URL of a cotype swagger.json spec and `<dest>` is the location of the `.ts` file to be generated.
 
 ```
-npx cotype-client https://example.com/rest/swagger.json ./lib/Api.ts
+npx @cotype/build-client https://example.com/rest/swagger.json ./lib/Api.ts
 ```
+
+#### Bin
+
+This package exposes the `cotype-build-client` binary when being installed as a
+dependency or globally.
 
 ## Configuration
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "bin": {
-    "build-client": "./lib/cli.js"
+    "cotype-build-client": "./lib/cli.js"
   },
   "scripts": {
     "build": "tsc",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,5 +22,5 @@ if (spec && dest) {
     console.error("Missing config file: client.config.js");
   }
 } else {
-  console.error(`Usage: cotype-client <spec> <dest>`);
+  console.error(`Usage: cotype-build-client <spec> <dest>`);
 }


### PR DESCRIPTION
In order to not collide with other binaries that might build a client I propose to rename the exposed bin to `cotype-build-client`.

I came here because I found the previous usage docs unintuitive since it used two different bins in the example.