### PR TITLE
docs: explain that this tool uses a config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ npx cotype-client https://example.com/rest/swagger.json ./lib/Api.ts
 
 ## Configuration
 
+The tool looks for a `client.config.js` in the provided dest folder or any of its parents
+when being used via cli.
+
+### Joining
+
 Requests to the cotype REST api can specify if they want to _join_ data of referenced contents (rather than just returning their IDs and links).
 
 For each endpoint we can fine-tune which data should be joined:


### PR DESCRIPTION
In order to prevent "BUT WHERE?!" effects when people (ich mein mich) read the documentation before trying out the tool.